### PR TITLE
Using the attribute name "app:font" does not compile in the new font system of Android O

### DIFF
--- a/slyce-messaging/src/main/java/it/slyce/messaging/view/text/FontTextView.java
+++ b/slyce-messaging/src/main/java/it/slyce/messaging/view/text/FontTextView.java
@@ -53,7 +53,7 @@ public class FontTextView extends TextView {
                     defStyleAttr,
                     defStyleRes);
 
-            font = a.getString(R.styleable.FontTextView_font);
+            font = a.getString(R.styleable.FontTextView_fontCustom);
             a.recycle();
         }
 

--- a/slyce-messaging/src/main/res/layout/fragment_slyce_messaging.xml
+++ b/slyce-messaging/src/main/res/layout/fragment_slyce_messaging.xml
@@ -71,7 +71,7 @@
             android:textColor="@color/text_navy"
             android:textColorHint="@color/text_navy_transparent_50"
             android:textSize="14sp"
-            app:font="museo_sans_300.otf" />
+            app:fontCustom="museo_sans_300.otf" />
 
 
         <ImageView

--- a/slyce-messaging/src/main/res/layout/item_message_external_media.xml
+++ b/slyce-messaging/src/main/res/layout/item_message_external_media.xml
@@ -27,7 +27,7 @@
             android:textAllCaps="true"
             android:textColor="@color/text_white"
             android:textSize="16sp"
-            app:font="museo_sans_500.otf"
+            app:fontCustom="museo_sans_500.otf"
             tools:text="JF" />
 
         <de.hdodenhof.circleimageview.CircleImageView

--- a/slyce-messaging/src/main/res/layout/item_message_external_text.xml
+++ b/slyce-messaging/src/main/res/layout/item_message_external_text.xml
@@ -28,7 +28,7 @@
             android:textAllCaps="true"
             android:textColor="@color/text_white"
             android:textSize="16sp"
-            app:font="museo_sans_500.otf"
+            app:fontCustom="museo_sans_500.otf"
             tools:text="JF"/>
 
         <de.hdodenhof.circleimageview.CircleImageView
@@ -67,7 +67,7 @@
             android:gravity="left"
             android:textColor="@color/text_navy"
             android:textSize="14sp"
-            app:font="museo_sans_500.otf"
+            app:fontCustom="museo_sans_500.otf"
             tools:text="You can get pizza at Zio's. It is located just beneath your office!"/>
     </FrameLayout>
 

--- a/slyce-messaging/src/main/res/layout/item_message_user_media.xml
+++ b/slyce-messaging/src/main/res/layout/item_message_user_media.xml
@@ -28,7 +28,7 @@
             android:textAllCaps="true"
             android:textColor="@color/text_white"
             android:textSize="16sp"
-            app:font="museo_sans_500.otf"
+            app:fontCustom="museo_sans_500.otf"
             tools:text="JF" />
 
         <de.hdodenhof.circleimageview.CircleImageView

--- a/slyce-messaging/src/main/res/layout/item_message_user_text.xml
+++ b/slyce-messaging/src/main/res/layout/item_message_user_text.xml
@@ -28,7 +28,7 @@
             android:textAllCaps="true"
             android:textColor="@color/text_white"
             android:textSize="16sp"
-            app:font="museo_sans_500.otf"
+            app:fontCustom="museo_sans_500.otf"
             tools:text="JF"/>
 
         <de.hdodenhof.circleimageview.CircleImageView
@@ -65,7 +65,7 @@
             android:gravity="left"
             android:textColor="@color/text_navy"
             android:textSize="14sp"
-            app:font="museo_sans_500.otf"
+            app:fontCustom="museo_sans_500.otf"
             tools:text="In need of pizza. Can you help?"/>
     </FrameLayout>
 

--- a/slyce-messaging/src/main/res/values/attrs.xml
+++ b/slyce-messaging/src/main/res/values/attrs.xml
@@ -28,7 +28,7 @@
     </declare-styleable>
 
     <declare-styleable name="FontTextView">
-        <attr name="font" format="string"/>
+        <attr name="fontCustom" format="string"/>
     </declare-styleable>
 
     <declare-styleable name="SlyceMessagingTheme">


### PR DESCRIPTION
Since the new type system in Android O (and it's support libraries) the usage of the custom View attribute "app:font" causes compile-time errors. 

This commit does a small fix by renaming it to "app:fontCustom". In the long term the library should switch to the new custom typeface system altogether. 

See this official giude: [Working With Fonts](https://developer.android.com/preview/features/working-with-fonts.html) for more info about the new sytem.